### PR TITLE
Add new key types to fact and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Facts
 Facts with the following formats are created, which correspond with the
 parameters for the `ssh_authorized_key` type:
 
-* `<username>_ssh(rsa|dsa)key`
-* `<username>_ssh(rsa|dsa)key_comment`
-* `<username>_ssh(rsa|dsa)key_type`
+* `<username>_ssh(rsa|dsa|ecdsa|ed25519)key`
+* `<username>_ssh(rsa|dsa|ecdsa|ed25519)key_comment`
+* `<username>_ssh(rsa|dsa|ecdsa|ed25519)key_type`
 
 The list of users whose public keys are to be collected as facts is configured
 by the `user_ssh_pubkey` fact, which can be set using external facts. For
@@ -61,7 +61,7 @@ Keys are generated with null passphrases.
     parameter should generally be avoided, as it breaks the facts.
 
 - **type**
-    The key type: "dsa", "rsa", "ecdsa". Note that semantics of this parameter
+    The key type: "dsa", "rsa", "ecdsa", "ed25519". Note that semantics of this parameter
     are different from the `*_type` fact and "type" parameter for
     `ssh_authorized_key`.
 

--- a/lib/facter/user_ssh_pubkey.rb
+++ b/lib/facter/user_ssh_pubkey.rb
@@ -1,6 +1,6 @@
-# Fact: <username>_ssh(rsa|dsa)key,
-#       <username>_ssh(rsa|dsa)key_comment,
-#       <username>_ssh(rsa|dsa)key_type
+# Fact: <username>_ssh(rsa|dsa|ecdsa|ed25519)key,
+#       <username>_ssh(rsa|dsa|ecdsa|ed25519)key_comment,
+#       <username>_ssh(rsa|dsa|ecdsa|ed25519)key_type
 #
 # Purpose:
 #   Collect users' SSH public keys (presumably for exported resources).
@@ -20,7 +20,7 @@ module Facter::UserSshPubkey
     user = Etc.getpwnam(username)
     sshdir = File.join(user.dir, '.ssh')
 
-    [ 'rsa', 'dsa' ].each do |keytype|
+    [ 'rsa', 'dsa', 'ecdsa', 'ed25519' ].each do |keytype|
       pubfile = "id_#{keytype}.pub"
       pubpath = File.join(sshdir, pubfile)
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,7 +17,7 @@
 #   parameter should generally be avoided, as it breaks the facts.
 #
 # [*type*]
-#   The key type: "dsa", "rsa", "ecdsa". Note that semantics of this parameter
+#   The key type: "dsa", "rsa", "ecdsa", "ed25519". Note that semantics of this parameter
 #   are different from the `*_type` fact and "type" parameter for
 #   `ssh_authorized_key`.
 #


### PR DESCRIPTION
Hi Wil,

I added the new key types to the facter fact and the documentation where missing. Great module!

Thanks,
Michael