### PR TITLE
Release/1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+2016-10-24 - Release 1.0.0
+--------------------------
+
+Bugfixes:
+
+* #11 Puppet 4 compatibility due to new rule against uppercase letters as
+first character of identifiers.
+* #13 Tests work again.
+
+Enhancement:
+
+* #1, #10, #17 Support ECDSA keys.
+* #13 Test against Ruby 2.1.9.
+* #13 Test against Puppet 4.
+* #9 Include example usage.
+
+Incompatibilities:
+
+* #13 Drop support for Ruby 1.8.7. (We no longer test against but it might
+work.)
+* #13 Drop support for Puppet 2.7. (We no longer test against but it might
+work.)
+
+
 2014-10-11 - Release 0.2.2
 --------------------------
 

--- a/metadata.json
+++ b/metadata.json
@@ -58,7 +58,8 @@
       "operatingsystemrelease": [
         "10.04",
         "12.04",
-        "14.04"
+        "14.04",
+        "16.04"
       ]
     }
   ],
@@ -70,7 +71,7 @@
     },
     {
       "name": "puppet",
-      "version_requirement": ">=2.7.20 <4.0.0"
+      "version_requirement": ">=3.0.0 <5.0.0"
     }
   ],
   "source": "git://github.com/wcooley/puppet-user_ssh_pubkey",
@@ -82,5 +83,5 @@
     "fact",
     "facter"
   ],
-  "version": "0.2.2"
+  "version": "1.0.0"
 }


### PR DESCRIPTION
Bugfixes:
- #11 Puppet 4 compatibility due to new rule against uppercase letters as
  first character of identifiers.
- #13 Tests work again.

Enhancement:
- #1, #10, #17 Support ECDSA keys.
- #13 Test against Ruby 2.1.9.
- #13 Test against Puppet 4.
- #9 Include example usage.

Incompatibilities:
- #13 Drop support for Ruby 1.8.7. (We no longer test against but it might
  work.)
- #13 Drop support for Puppet 2.7. (We no longer test against but it might
  work.)
